### PR TITLE
docs: fix IPv6 firewall rule grammar

### DIFF
--- a/source/plugins/ipv6.rst
+++ b/source/plugins/ipv6.rst
@@ -303,9 +303,9 @@ IPv6 Firewall
 For using and managing firewall rules with an IPv6 supported isolated network, CloudStack provides following APIs:
 
 -  ``listIpv6FirewallRules`` - To list existing IPv6 firewall rules for a network.
--  ``createIpv6FirewallRule`` - To create a new IPv6 firewall rules for a network.
--  ``updateIpv6FirewallRule`` - To update an existing IPv6 firewall rules for a network.
--  ``deleteIpv6FirewallRule`` - To delete an existing IPv6 firewall rules for a network.
+-  ``createIpv6FirewallRule`` - To create a new IPv6 firewall rule for a network.
+-  ``updateIpv6FirewallRule`` - To update an existing IPv6 firewall rule for a network.
+-  ``deleteIpv6FirewallRule`` - To delete an existing IPv6 firewall rule for a network.
 
 These operations are also available using UI in the network details view of an IPv6 supported network.
 


### PR DESCRIPTION
## Summary
- fix singular/plural grammar for IPv6 firewall API bullets

## Testing
- `make html`


------
https://chatgpt.com/codex/tasks/task_b_68c0129e553c8327979ee0447a35f5cc

<!-- readthedocs-preview cloudstack-documentation start -->
----
📚 Documentation preview 📚: https://cloudstack-documentation--3.org.readthedocs.build/en/3/

<!-- readthedocs-preview cloudstack-documentation end -->